### PR TITLE
feature: aws keys optional while constructing ChromeInstaller object

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Use in your AWS Lambda function. Requires Node 6.10.
 let ChromeInstaller = require('@hackstudio/puppeteer-lambda-launcher')
 
 ChromeInstaller = new ChromeInstaller({ 
-  accessKeyId: 'AKIAxxxxxxxxxxxx', 
-  secretAccessKey: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx', 
+  accessKeyId: 'AKIAxxxxxxxxxxxx', 			//optional
+  secretAccessKey: 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',    //optional
   s3Bucket:'bucket_name_xxx', s3Key:'s3_object_name', 
   executePath:'xxxxxxxxxxxxx'
 })

--- a/source/index.js
+++ b/source/index.js
@@ -19,7 +19,11 @@ class ChromeInstaller {
       this.setupChromePath,
       executePath,
     );
-    AWS.config.update({ accessKeyId, secretAccessKey });
+    // aws keys if not provided will be picked from the system ~/.aws/credentials
+    // or if running on AWS Lambda, then from the role assigned to the function
+    if (typeof accessKeyId == 'string' && typeof secretAccessKey == 'string') {
+ 	AWS.config.update({ accessKeyId, secretAccessKey });
+    }
     this.s3 = new AWS.S3({ apiVersion: '2006-03-01' });
     this.s3Bucket = s3Bucket;
     this.s3Key = s3Key;


### PR DESCRIPTION
The keys if not provided will be searched in the deafult directory, ~/.aws/. 
Also if running on AWS Lambda, certain roles may have been assigned to it which gives the lambda function to access S3. So need for keys in that case. This is the case that I recently encountered. 
Generating keys is always more dangerous than avoiding them and instead use roles to access AWS resources. So with this feature, we can provide that.
Also thanks a lot for your repo. It greatly helped me in web scraping on Lambda.